### PR TITLE
fixing quoting eosargentina

### DIFF
--- a/config.ini
+++ b/config.ini
@@ -75,4 +75,4 @@ p2p-peer-address = 10.17.1.95:19876
 peer-key = "EOS6bTTpWZ5ooHT39ySL6a8NLGeqxTfZd6skNB5dQv2zKWW94cJXj"
 # EOS Argentina
 p2p-peer-address = 10.17.1.54:5432
-peer-key = EOS7jDQf5BSv1G1fbKoZP7rF5Zb5tRi56WA2n53GXGfYA2kHTyiwH
+peer-key = "EOS7jDQf5BSv1G1fbKoZP7rF5Zb5tRi56WA2n53GXGfYA2kHTyiwH"

--- a/producer-configs/argentinaeos.ini
+++ b/producer-configs/argentinaeos.ini
@@ -1,8 +1,8 @@
 
 http-server-address = 10.17.1.54:8888
 p2p-peer-address = 10.17.1.54:5432
-peer-key = EOS7jDQf5BSv1G1fbKoZP7rF5Zb5tRi56WA2n53GXGfYA2kHTyiwH
-producer-public-key = EOS6GGYV5JYWiwdhpppkvc3kgDttpEcaG5YiEbmjxdyC5324jtGsb"
+peer-key = "EOS7jDQf5BSv1G1fbKoZP7rF5Zb5tRi56WA2n53GXGfYA2kHTyiwH"
+producer-public-key = "EOS6GGYV5JYWiwdhpppkvc3kgDttpEcaG5YiEbmjxdyC5324jtGsb"
 producer-name = argentinaeos
 producer-name = eosargentina
 producer-name = eosar3eosar3


### PR DESCRIPTION
Looks like we had a single quote in the previous pr, quoting it everywhere for consistency. 